### PR TITLE
Guard edits against navigation

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form-model.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form-model.ts
@@ -51,6 +51,7 @@ export interface QuestionSubmissionFormModel {
   isLoading: boolean;
   isLoaded: boolean;
   isTabExpanded: boolean;
+  isResponseChanged: boolean;
 }
 
 /**

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -102,6 +102,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     isLoading: false,
     isLoaded: false,
     isTabExpanded: true,
+    isResponseChanged: false,
     feedbackQuestionId: '',
 
     questionNumber: 0,
@@ -181,6 +182,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
   toggleQuestionTab(): void {
     this.model.isTabExpanded = !this.model.isTabExpanded;
+    this.model.isResponseChanged = false;
     this.formModelChange.emit(this.model);
   }
 
@@ -300,6 +302,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
         ...this.model.recipientSubmissionForms[index],
         [field]: data,
       };
+      this.model.isResponseChanged = true;
 
       this.updateIsValidByQuestionConstraint();
       this.formModelChange.emit(this.model);

--- a/src/web/app/guards/edit.guard.ts
+++ b/src/web/app/guards/edit.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@angular/core";
+import { CanDeactivate } from "@angular/router";
+
+export interface ComponentCanDeactivate {
+  canDeactivate: () => boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EditGuard implements CanDeactivate<ComponentCanDeactivate> {
+  MESSAGE: string = 'You have unsaved changes. Are you sure to navigate away?';
+
+  canDeactivate(component: ComponentCanDeactivate): boolean {
+    if (!component.canDeactivate()) {
+      return confirm(this.MESSAGE);
+    }
+    return true;
+  }
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -1511,6 +1511,7 @@ export const EXAMPLE_RESPONDER_RUBRIC_SUBMISSION_FORM_MODEL: QuestionSubmissionF
   isLoading: false,
   isLoaded: true,
   isTabExpanded: true,
+  isResponseChanged: false,
   recipientList: [
     {
       recipientIdentifier: 'alice',

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -24,6 +24,7 @@
         (discardExistingQuestionChangesEvent)="discardExistingQuestionHandler(i)"
         (duplicateCurrentQuestionEvent)="duplicateCurrentQuestionHandler(i)"
         (deleteCurrentQuestionEvent)="deleteExistingQuestionHandler(i)" [(formModel)]="questionEditFormModels[i]"
+        (formModelChange)="triggerQuestionChange($event)"
         [isQuestionPublished]="sessionEditFormModel.publishStatus === FeedbackSessionPublishStatus.PUBLISHED"></tm-question-edit-form>
     </div>
     <a class="d-block text-end cursor-pointer" (click)="scrollToTopOfPage()">
@@ -40,7 +41,7 @@
   </div>
   <tm-question-edit-form *ngIf="isAddingQuestionPanelExpanded" [formMode]="QuestionEditFormMode.ADD"
     [numOfQuestions]="questionEditFormModels.length + 1"
-    (discardNewQuestionEvent)="isAddingQuestionPanelExpanded = false"
+    (discardNewQuestionEvent)="discardNewQuestion()"
     (createNewQuestionEvent)="createNewQuestionHandler()"
     [(formModel)]="newQuestionEditFormModel"></tm-question-edit-form>
   <br />

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.module.ts
@@ -24,11 +24,13 @@ import {
 } from './copy-questions-from-other-sessions-modal/copy-questions-from-other-sessions-modal.component';
 import { InstructorSessionEditPageComponent } from './instructor-session-edit-page.component';
 import { TemplateQuestionModalComponent } from './template-question-modal/template-question-modal.component';
+import { EditGuard } from '../../guards/edit.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: InstructorSessionEditPageComponent,
+    canDeactivate: [EditGuard],
   },
 ];
 

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.html
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.html
@@ -17,7 +17,7 @@
       [courseCandidates]="courseCandidates" [templateSessions]="templateSessions"
       [isCopyOtherSessionLoading]="isCopyOtherSessionLoading" (addNewSessionEvent)="addNewSessionHandler()"
       (copyOtherSessionsEvent)="copyFromOtherSessionsHandler()"
-      (closeEditFormEvent)="isSessionEditFormExpanded = false"></tm-session-edit-form>
+      (closeEditFormEvent)="closeAddForm()"></tm-session-edit-form>
   </div>
 </div>
 

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -547,6 +547,14 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
   }
 
   /**
+   * Closes the form to add a new session.
+   */
+  closeAddForm() {
+    this.isSessionEditFormExpanded = false;
+    this.editService.removeField(this.ADD_FORM_EDIT_ID);
+  }
+
+  /**
    * Submits the feedback session as instructor.
    */
   submitSessionAsInstructorEventHandler(rowIndex: Index): void {

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.module.ts
@@ -25,11 +25,13 @@ import {
 import {
   SessionsPermanentDeletionConfirmModalComponent,
 } from './sessions-permanent-deletion-confirm-modal/sessions-permanent-deletion-confirm-modal.component';
+import { EditGuard } from '../../guards/edit.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: InstructorSessionsPageComponent,
+    canDeactivate: [EditGuard],
   },
 ];
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -100,6 +100,7 @@
                                  (deleteCommentEvent)="deleteParticipantComment(i, $event)"
                                  [isQuestionCountOne]="isQuestionCountOne"
                                  [(isSubmitAllClicked)]="isSubmitAllClicked"
+                                 (formModelChange)="triggerModelChange($event)"
     ></tm-question-submission-form>
 
     <div class="row" *ngIf="questionsNeedingSubmission.length === 0">

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.module.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.module.ts
@@ -13,11 +13,13 @@ import {
 import { TeammatesCommonModule } from '../../components/teammates-common/teammates-common.module';
 import { SavingCompleteModalComponent } from './saving-complete-modal/saving-complete-modal.component';
 import { SessionSubmissionPageComponent } from './session-submission-page.component';
+import { EditGuard } from '../../guards/edit.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: SessionSubmissionPageComponent,
+    canDeactivate: [EditGuard],
   },
 ];
 

--- a/src/web/services/track-edit.service.ts
+++ b/src/web/services/track-edit.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from "@angular/core";
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TrackEditService {
+  private editingFields: Set<string> = new Set<string>();
+
+  /**
+   * Marks a field as being edited. The fields must be unique,
+   * or this service will not work properly.
+   * @param field The unique ID of the field.
+   */
+  addField(field: string) {
+    this.editingFields.add(field);
+  }
+
+  /**
+   * Marks a field as not being edited.
+   * @param field The unique ID of the field.
+   */
+  removeField(field: string) {
+    this.editingFields.delete(field);
+  }
+
+  /**
+   * Checks if any field is being edited.
+   */
+  isAnyFieldBeingEdited(): boolean {
+    return this.editingFields.size > 0;
+  }
+
+  /**
+   * Marks all fields as not being edited.
+   */
+  removeAllFields() {
+    this.editingFields = new Set<string>();
+  }
+}


### PR DESCRIPTION
Upon navigation, warns the user of unsaved changes.

**Outline of Solution**

* Use an `EditGuard` class to detect whether there are changes, if there are, prompt the user before navigating away.
* Use `HostListener` class from Angular to enforce such protection on reload and navigating to an external website.
* Any page component needing this protection should implement `ComponentCanDeactivate` interface, which has `canDeactivate(): boolean` method.
* `TrackEditService` is used to simplify the tracking of edits being made on a page.

There are 3 pages that I have implemented this edit protection:
1. Instructor's session edit page
2. Instructor's session page
3. Instructor/student's session submission
